### PR TITLE
Allow webkit2png width to be set on the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ prototype2pdf < urls.txt > my-prototype.pdf
 
 where `urls.txt` contains one URL per line.
 
+Optionally, the width of the screenshot to be taken using webkit2png can be
+specified as the first argument, $1, as follows, assuming a 150px width:
+
+```
+prototype2pdf < urls.txt > my-prototype.pdf 150
+```
+
 ## Todo
 
-- Allow width to be set on the command line instead of hard-coding it to 320px
 - Use a temporary directory to store the screenshots instead of the current
   directory
 - Make the screenshots appear in the PDF in the same order as the input URLs

--- a/prototype2pdf
+++ b/prototype2pdf
@@ -9,7 +9,7 @@ then
 fi
 
 while read url; do
-  webkit2png --fullsize --scale=1 --width=320 --clipwidth=1 $url > /dev/null
+  webkit2png --fullsize --scale=1 --width=${1:-320} --clipwidth=1 $url > /dev/null
 done
 
 convert *.png +repage -crop 1090x1603 +repage -units PixelsPerInch -density 150x150 -extent 1090x1603 -bordercolor transparent -border 75x75 pdf:-


### PR DESCRIPTION
Allow for the width of the screenshot taken by `webkit2png` to be taken on the command line, as requested in this project's to-do list. Updates the README, too. More details in each commit message.

I'm in two minds as to whether or not leaving the width value as `$1` without a named flag is the best way of doing this; something like `prototype2pdf ... -w 150` or whatever might be nicer.
